### PR TITLE
Include CoreGraphics header in MOOCGImageWrapper.h

### DIFF
--- a/MOOMaskedIconView/MOOCGImageWrapper.h
+++ b/MOOMaskedIconView/MOOCGImageWrapper.h
@@ -6,6 +6,11 @@
 //
 
 #import <Foundation/Foundation.h>
+#if TARGET_OS_IPHONE
+#import <CoreGraphics/CoreGraphics.h>
+#else
+#import <ApplicationServices/ApplicationServices.h>
+#endif
 
 @interface MOOCGImageWrapper : NSObject
 {


### PR DESCRIPTION
Just a small fix to include the CoreGraphics header in MOOCGImageWrapper.h.  In my project, UIKit.h is not in the prefix header, so I was having problems compiling without it.

I left a Mac vs. iOS #define in, since technically this file could work on either OS - even though the other UIKit-requiring classes obviously couldn't
